### PR TITLE
Use packet create static function

### DIFF
--- a/src/ErikPDev/AdvanceDeaths/Listeners/instantRespawn.php
+++ b/src/ErikPDev/AdvanceDeaths/Listeners/instantRespawn.php
@@ -19,7 +19,7 @@ class instantRespawn implements Listener{
      * @param PlayerJoinEvent $event
      */
     public function onJoin(PlayerJoinEvent $event){
-        $pk = new GameRulesChangedPacket::create(
+        $pk = GameRulesChangedPacket::create(
             ["doimmediaterespawn" => new BoolGameRule(true, false)]
         );
         $event->getPlayer()->getNetworkSession()->sendDataPacket($pk);
@@ -36,7 +36,7 @@ class instantRespawn implements Listener{
             return;
         }
         
-        $pk = new GameRulesChangedPacket::create(
+        $pk = GameRulesChangedPacket::create(
             ["doimmediaterespawn" => new BoolGameRule(true, false)]
         );
 

--- a/src/ErikPDev/AdvanceDeaths/Listeners/instantRespawn.php
+++ b/src/ErikPDev/AdvanceDeaths/Listeners/instantRespawn.php
@@ -5,6 +5,7 @@ namespace ErikPDev\AdvanceDeaths\Listeners;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\event\entity\EntityTeleportEvent;
+use pocketmine\network\mcpe\protocol\GameRulesChangedPacket;
 use pocketmine\network\mcpe\protocol\types\BoolGameRule;
 use pocketmine\player\Player;
 class instantRespawn implements Listener{
@@ -18,8 +19,9 @@ class instantRespawn implements Listener{
      * @param PlayerJoinEvent $event
      */
     public function onJoin(PlayerJoinEvent $event){
-        $pk = new \pocketmine\network\mcpe\protocol\GameRulesChangedPacket();
-        $pk->gameRules = ["doimmediaterespawn" => new BoolGameRule(true, false)];
+        $pk = new GameRulesChangedPacket::create(
+            ["doimmediaterespawn" => new BoolGameRule(true, false)]
+        );
         $event->getPlayer()->getNetworkSession()->sendDataPacket($pk);
     }
     
@@ -34,8 +36,9 @@ class instantRespawn implements Listener{
             return;
         }
         
-        $pk = new \pocketmine\network\mcpe\protocol\GameRulesChangedPacket();
-        $pk->gameRules = ["doimmediaterespawn" => new BoolGameRule(true, false)];
+        $pk = new GameRulesChangedPacket::create(
+            ["doimmediaterespawn" => new BoolGameRule(true, false)]
+        );
 
         $player->getNetworkSession()->sendDataPacket($pk);
     }

--- a/src/ErikPDev/AdvanceDeaths/effects/Lighting.php
+++ b/src/ErikPDev/AdvanceDeaths/effects/Lighting.php
@@ -6,7 +6,6 @@ use pocketmine\network\mcpe\protocol\AddActorPacket;
 use pocketmine\network\mcpe\protocol\PlaySoundPacket;
 use pocketmine\Server;
 
-use pocketmine\math\Vector3;
 class Lighting{
     private $player;
     function __construct($player){
@@ -15,22 +14,29 @@ class Lighting{
     
     public function run(){
         $player = $this->player;
-        $light = new AddActorPacket();
-        $light->type = "minecraft:lightning_bolt";
-        $light->entityRuntimeId = Entity::nextRuntimeId();
-        $light->metadata = [];
-        $light->motion = null;
-        $light->yaw = $player->getYaw();
-        $light->pitch = $player->getPitch();
-        $light->position = new Vector3($player->getX(), $player->getY(), $player->getZ());
-        Server::getInstance()->broadcastPacket($player->getWorld()->getPlayers(), $light);
-        $sound = new PlaySoundPacket();
-        $sound->soundName = "ambient.weather.thunder";
-        $sound->x = $player->getX();
-        $sound->y = $player->getY();
-        $sound->z = $player->getZ();
-        $sound->volume = 1;
-        $sound->pitch = 1;
-        Server::getInstance()->broadcastPacket($player->getWorld()->getPlayers(), $sound);
+        $location = $player->getLocation();
+        $id = Entity::nextRuntimeId();
+        $light = AddActorPacket::create(
+            $id, //Actor unique ID not implemented
+            $id,
+            "minecraft:lightning_bolt",
+            $location->asVector3(),
+            null,
+            $location->pitch,
+            $location->yaw,
+            $location->yaw, //Head yaw not implemented
+            [],
+            [],
+            []
+        );
+        $sound = PlaySoundPacket::create(
+            "ambient.weather.thunder",
+            $location->x,
+            $location->y,
+            $location->z,
+            1,
+            1
+        );
+        Server::getInstance()->broadcastPackets($player->getWorld()->getPlayers(), [$light, $sound]);
     }
 }


### PR DESCRIPTION
## Introduction
Using the static create function solves various problems, such as changes like `entityRuntimeId => actorRuntimeId`.

## Backwards compatibility
These changes are backwards compatible.